### PR TITLE
Reject promise when ASAM action fails

### DIFF
--- a/android/src/main/java/com/robinpowered/RNMDMManager/RNMobileDeviceManagerModule.java
+++ b/android/src/main/java/com/robinpowered/RNMDMManager/RNMobileDeviceManagerModule.java
@@ -164,7 +164,12 @@ public class RNMobileDeviceManagerModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void enableAutonomousSingleAppMode(final Promise promise) {
         try {
-            promise.resolve(enableLockState());
+            boolean locked = enableLockState();
+            if (locked) {
+              promise.resolve(locked);
+            } else {
+              promise.reject(new Error("Unable to enable ASAM"));
+            }
         } catch (Exception e) {
             promise.reject(e);
         }
@@ -173,7 +178,12 @@ public class RNMobileDeviceManagerModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void disableAutonomousSingleAppMode(final Promise promise) {
         try {
-            promise.resolve(disableLockState());
+            boolean unlocked = disableLockState();
+            if (unlocked) {
+              promise.resolve(unlocked);
+            } else {
+              promise.reject(new Error("Unable to disable ASAM"));
+            }
         } catch (Exception e) {
             promise.reject(e);
         }

--- a/ios/RNMobileDeviceManager.m
+++ b/ios/RNMobileDeviceManager.m
@@ -154,7 +154,11 @@ RCT_EXPORT_METHOD(enableAutonomousSingleAppMode: (RCTPromiseResolveBlock)resolve
     dispatch_async(dispatch_get_main_queue(), ^{
         UIAccessibilityRequestGuidedAccessSession(YES, ^(BOOL didSucceed) {
             dispatch_semaphore_signal(self.asamSem);
-            resolve(@(didSucceed));
+            if (didSucceed) {
+                resolve(@(didSucceed));
+            } else {
+                reject(@"Action failed", @"Unable to enable ASAM", nil);
+            }
         });
     });
 }
@@ -166,7 +170,11 @@ RCT_EXPORT_METHOD(disableAutonomousSingleAppMode: (RCTPromiseResolveBlock)resolv
     dispatch_async(dispatch_get_main_queue(), ^{
         UIAccessibilityRequestGuidedAccessSession(NO, ^(BOOL didSucceed) {
             dispatch_semaphore_signal(self.asamSem);
-            resolve(@(didSucceed));
+            if (didSucceed) {
+                resolve(@(didSucceed));
+            } else {
+                reject(@"Action failed", @"Unable to disable ASAM", nil);
+            }
         });
     });
 }


### PR DESCRIPTION
Reject promise when ASAM action (enable/disable) fails instead of resolving response as false.