### PR TITLE
Android parity PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,23 @@ componentWillUnmount() {
 }
 ```
 
+## Additional steps for Android
+
+```xml
+<meta-data android:name="android.content.APP_RESTRICTIONS"
+  android:resource="@xml/app_restrictions" />
+```
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<restrictions xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <restriction
+    android:key="downloadOnCellular"
+    android:title="@string/download_on_cell_title"
+    android:restrictionType="bool"
+    android:description="@string/download_on_cell_description"
+    android:defaultValue="true" />
+
+</restrictions>
+```

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ componentWillUnmount() {
 
 ## Additional steps for Android
 
+Schema and extra settings needed for `AndroidManifest.xml` to obtain app configurations from MDM provider. [Android documentation regarding this](https://developer.android.com/work/managed-configurations.html)
+
 ```xml
 <meta-data android:name="android.content.APP_RESTRICTIONS"
   android:resource="@xml/app_restrictions" />

--- a/android/src/main/java/com/robinpowered/RNMDMManager/RNMobileDeviceManagerModule.java
+++ b/android/src/main/java/com/robinpowered/RNMDMManager/RNMobileDeviceManagerModule.java
@@ -31,7 +31,6 @@ public class RNMobileDeviceManagerModule extends ReactContextBaseJavaModule impl
     public static final String APP_LOCKING_ALLOWED = "appLockingAllowed";
 
     private BroadcastReceiver restrictionReceiver;
-    private BroadcastReceiver appLockReceiver;
 
     public RNMobileDeviceManagerModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -50,7 +49,7 @@ public class RNMobileDeviceManagerModule extends ReactContextBaseJavaModule impl
     private void maybeRegisterReceiver() {
         final ReactApplicationContext reactContext = getReactApplicationContext();
 
-        if (restrictionReceiver != null && appLockReceiver != null) {
+        if (restrictionReceiver != null) {
             return;
         }
 

--- a/android/src/main/java/com/robinpowered/RNMDMManager/RNMobileDeviceManagerModule.java
+++ b/android/src/main/java/com/robinpowered/RNMDMManager/RNMobileDeviceManagerModule.java
@@ -26,6 +26,7 @@ public class RNMobileDeviceManagerModule extends ReactContextBaseJavaModule impl
     public static final String MODULE_NAME = "MobileDeviceManager";
 
     public static final String APP_CONFIG_CHANGED = "react-native-mdm/managedAppConfigDidChange";
+    public static final String APP_LOCK_STATUS_CHANGED = "react-native-mdm/appLockStatusDidChange";
 
     private BroadcastReceiver restrictionReceiver;
 
@@ -118,6 +119,7 @@ public class RNMobileDeviceManagerModule extends ReactContextBaseJavaModule impl
     public @Nullable Map<String, Object> getConstants() {
         HashMap<String, Object> constants = new HashMap<String, Object>();
         constants.put("APP_CONFIG_CHANGED", APP_CONFIG_CHANGED);
+        constants.put("APP_LOCK_STATUS_CHANGED", APP_LOCK_STATUS_CHANGED);
         return constants;
     }
 

--- a/android/src/main/java/com/robinpowered/RNMDMManager/RNMobileDeviceManagerModule.java
+++ b/android/src/main/java/com/robinpowered/RNMDMManager/RNMobileDeviceManagerModule.java
@@ -8,10 +8,8 @@ import com.facebook.react.bridge.Promise;
 
 // For MDM
 import android.app.Activity;
-import android.app.admin.DeviceAdminReceiver;
 import android.content.RestrictionsManager;
 import android.app.ActivityManager;
-import android.app.admin.DevicePolicyManager;
 import android.os.Bundle;
 import android.os.Build;
 import android.content.Context;
@@ -102,16 +100,6 @@ public class RNMobileDeviceManagerModule extends ReactContextBaseJavaModule impl
     }
 
     public boolean isLockStatePermitted() {
-        // DevicePolicyManager dpm = (DevicePolicyManager)
-        //         getReactApplicationContext().getSystemService(Context.DEVICE_POLICY_SERVICE);
-        // ActivityManager am = (ActivityManager) getReactApplicationContext().getSystemService(Context.ACTIVITY_SERVICE);
-
-        // boolean isPinned = false;
-        // if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-        //     isPinned = am.getLockTaskModeState() == ActivityManager.LOCK_TASK_MODE_PINNED;
-        // }
-
-        // return dpm.isLockTaskPermitted(getReactApplicationContext().getPackageName()) && !isPinned;
         return true;
     }
 

--- a/android/src/main/java/com/robinpowered/RNMDMManager/RNMobileDeviceManagerModule.java
+++ b/android/src/main/java/com/robinpowered/RNMDMManager/RNMobileDeviceManagerModule.java
@@ -40,15 +40,13 @@ public class RNMobileDeviceManagerModule extends ReactContextBaseJavaModule impl
     }
 
     private void maybeUnregisterReceiver() {
-        if (restrictionReceiver == null && appLockReceiver == null) {
+        if (restrictionReceiver == null) {
             return;
         }
 
         getReactApplicationContext().unregisterReceiver(restrictionReceiver);
-        getReactApplicationContext().unregisterReceiver(appLockReceiver);
 
         restrictionReceiver = null;
-        appLockReceiver = null;
     }
 
     private void maybeRegisterReceiver() {
@@ -77,26 +75,6 @@ public class RNMobileDeviceManagerModule extends ReactContextBaseJavaModule impl
             }
         };
         reactContext.registerReceiver(restrictionReceiver,restrictionFilter);
-
-        IntentFilter appLockFilter = new IntentFilter();
-        appLockFilter.addAction(DeviceAdminReceiver.ACTION_LOCK_TASK_ENTERING);
-        appLockFilter.addAction(DeviceAdminReceiver.ACTION_LOCK_TASK_EXITING);
-        BroadcastReceiver appLockReceiver = new BroadcastReceiver() {
-            @Override
-            public void onReceive(Context context, Intent intent) {
-                WritableNativeMap data = new WritableNativeMap();
-
-                data.putBoolean(APP_LOCKED, isLockState());
-                data.putBoolean(APP_LOCKING_ALLOWED, isLockStatePermitted());
-
-                if (reactContext.hasActiveCatalystInstance()) {
-                    reactContext
-                            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                            .emit(APP_LOCK_STATUS_CHANGED, data);
-                }
-            }
-        };
-        reactContext.registerReceiver(appLockReceiver, appLockFilter);
     }
 
     public boolean enableLockState() {
@@ -124,16 +102,17 @@ public class RNMobileDeviceManagerModule extends ReactContextBaseJavaModule impl
     }
 
     public boolean isLockStatePermitted() {
-        DevicePolicyManager dpm = (DevicePolicyManager)
-                getReactApplicationContext().getSystemService(Context.DEVICE_POLICY_SERVICE);
-        ActivityManager am = (ActivityManager) getReactApplicationContext().getSystemService(Context.ACTIVITY_SERVICE);
+        // DevicePolicyManager dpm = (DevicePolicyManager)
+        //         getReactApplicationContext().getSystemService(Context.DEVICE_POLICY_SERVICE);
+        // ActivityManager am = (ActivityManager) getReactApplicationContext().getSystemService(Context.ACTIVITY_SERVICE);
 
-        boolean isPinned = false;
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            isPinned = am.getLockTaskModeState() == ActivityManager.LOCK_TASK_MODE_PINNED;
-        }
+        // boolean isPinned = false;
+        // if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        //     isPinned = am.getLockTaskModeState() == ActivityManager.LOCK_TASK_MODE_PINNED;
+        // }
 
-        return dpm.isLockTaskPermitted(getReactApplicationContext().getPackageName()) && !isPinned;
+        // return dpm.isLockTaskPermitted(getReactApplicationContext().getPackageName()) && !isPinned;
+        return true;
     }
 
     public boolean isLockState() {
@@ -155,16 +134,17 @@ public class RNMobileDeviceManagerModule extends ReactContextBaseJavaModule impl
     public @Nullable Map<String, Object> getConstants() {
         HashMap<String, Object> constants = new HashMap<String, Object>();
         constants.put("APP_CONFIG_CHANGED", APP_CONFIG_CHANGED);
-        constants.put("APP_LOCK_STATUS_CHANGED", APP_LOCK_STATUS_CHANGED);
         constants.put("APP_LOCKED", APP_LOCKED);
         return constants;
     }
 
     private boolean isMDMSupported() {
+        // If app is running on any version that's older than lollipop, answer is no
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
             return false;
         }
 
+        // Else, we look at restrictions manager and see if there's any app config settings in there
         RestrictionsManager restrictionsManager = (RestrictionsManager) getReactApplicationContext().getSystemService(Context.RESTRICTIONS_SERVICE);
         return restrictionsManager.getApplicationRestrictions().size() > 0;
     }
@@ -231,6 +211,7 @@ public class RNMobileDeviceManagerModule extends ReactContextBaseJavaModule impl
         }
     }
 
+    // Life cycle methods
     @Override
     public void initialize() {
         getReactApplicationContext().addLifecycleEventListener(this);
@@ -250,5 +231,6 @@ public class RNMobileDeviceManagerModule extends ReactContextBaseJavaModule impl
     @Override
     public void onHostDestroy() {
         maybeUnregisterReceiver();
+        getReactApplicationContext().removeLifecycleEventListener(this);
     }
 }

--- a/android/src/main/java/com/robinpowered/RNMDMManager/RNMobileDeviceManagerModule.java
+++ b/android/src/main/java/com/robinpowered/RNMDMManager/RNMobileDeviceManagerModule.java
@@ -26,9 +26,6 @@ public class RNMobileDeviceManagerModule extends ReactContextBaseJavaModule impl
     public static final String MODULE_NAME = "MobileDeviceManager";
 
     public static final String APP_CONFIG_CHANGED = "react-native-mdm/managedAppConfigDidChange";
-    public static final String APP_LOCK_STATUS_CHANGED = "react-native-mdm/appLockStatusDidChange";
-    public static final String APP_LOCKED = "appLocked";
-    public static final String APP_LOCKING_ALLOWED = "appLockingAllowed";
 
     private BroadcastReceiver restrictionReceiver;
 
@@ -121,7 +118,6 @@ public class RNMobileDeviceManagerModule extends ReactContextBaseJavaModule impl
     public @Nullable Map<String, Object> getConstants() {
         HashMap<String, Object> constants = new HashMap<String, Object>();
         constants.put("APP_CONFIG_CHANGED", APP_CONFIG_CHANGED);
-        constants.put("APP_LOCKED", APP_LOCKED);
         return constants;
     }
 


### PR DESCRIPTION
Due to some fundamental differences between the Android & iOS app lock API, this PR will modify the APIs slightly.

Important notes:
- `isAppLockingAllowed()` will always return true since we can **always** trigger `App Pinning / Guided Access` programmatically even if we're not able to permanently lock an app.
- There are no functional listeners available atm for Android in terms of listening to the app lock actions. `DeviceAdminReceiver` seems to have the `onLockTaskModeEntering()` & `onLockTaskModeExiting()` listeners but unclear on how we can get them to work. Can revisit in the future.