### PR TITLE
Revert changes to isLockStatePermitted()

### DIFF
--- a/android/src/main/java/com/robinpowered/RNMDMManager/RNMobileDeviceManagerModule.java
+++ b/android/src/main/java/com/robinpowered/RNMDMManager/RNMobileDeviceManagerModule.java
@@ -97,7 +97,10 @@ public class RNMobileDeviceManagerModule extends ReactContextBaseJavaModule impl
     }
 
     public boolean isLockStatePermitted() {
-        return true;
+        DevicePolicyManager dpm = (DevicePolicyManager)
+                getReactApplicationContext().getSystemService(Context.DEVICE_POLICY_SERVICE);
+
+        return dpm.isLockTaskPermitted(getReactApplicationContext().getPackageName());
     }
 
     public boolean isLockState() {


### PR DESCRIPTION
In the previous PR, I modified `isLockStatePermitted()` to always return true because an app can always call the `startLockTask()` to either _pin_ or _truly lock_ an app. However, that shouldn't be the case, since in the Rooms app, we do not want a device that does not have the _true locking privilege_ to actually pin an app automatically (user's discretion).

Hence this PR will bring back the check in order to determine whether the app has the _true locking privilege_ .