### PR TITLE
Added requiresMainQueueSetup to prevent warning and future side-effects in RCCManagerModule

### DIFF
--- a/ios/RNMobileDeviceManager.m
+++ b/ios/RNMobileDeviceManager.m
@@ -148,6 +148,11 @@ RCT_EXPORT_MODULE();
     return dispatch_queue_create(OPERATION_QUEUE_NAME, DISPATCH_QUEUE_SERIAL);
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 RCT_EXPORT_METHOD(isSupported: (RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {


### PR DESCRIPTION
This doesn't change any behavior but supports an upcoming behavior change where certain functionality would be moved into background processes unless otherwise specified.

This also prevents a warning from being shown. 

Prior art:
https://github.com/wix/react-native-navigation/pull/1983
https://github.com/facebook/react-native/commit/220034c4d4c8a52f424e05c291a62b63b74447f3