### PR TITLE
Bugfix - Flip requiresMainQueue to false

### DIFF
--- a/ios/RNMobileDeviceManager.m
+++ b/ios/RNMobileDeviceManager.m
@@ -150,7 +150,7 @@ RCT_EXPORT_MODULE();
 
 + (BOOL)requiresMainQueueSetup
 {
-    return YES;
+    return NO;
 }
 
 RCT_EXPORT_METHOD(isSupported: (RCTPromiseResolveBlock)resolve


### PR DESCRIPTION
Because of how our native module operates by using semaphores on different threads, we should never be running on the main thread as it could potentially cause the app to freeze when the main thread gets into a deadlock. Oversight on my end when I approved #15, totally forgot about the multi-threaded operations. 