### PR TITLE
Upgrade Swift syntax to 4.2

### DIFF
--- a/ios/AppConfigSettingsFramework.xcodeproj/project.pbxproj
+++ b/ios/AppConfigSettingsFramework.xcodeproj/project.pbxproj
@@ -105,7 +105,7 @@
 				TargetAttributes = {
 					C91CCA6E1C691C0700E71355 = {
 						CreatedOnToolsVersion = 7.2.1;
-						LastSwiftMigration = 0830;
+						LastSwiftMigration = 1010;
 					};
 				};
 			};
@@ -254,7 +254,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -273,7 +274,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.appconfig.AppConfigSettingsFramework;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 3.0;
+				SWIFT_SWIFT3_OBJC_INFERENCE = On;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
## Changes
This updates the Swift syntax to Swift 4.2.

## Motivation
The newest XCode update (`10.2`) enforces Swift >4 versions. This library can prevent successful compilation due to the Swift version in this package being `3.0`

## Method
I used XCode's built-in [migration tool](https://swift.org/migration-guide-swift4.2/) via XCode 10.1.


Closes #18 