### PR TITLE
Fix deprecated Gradle syntax

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,5 +31,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
Gradle deprecate the use of `compile` in favor of `implementation` and `api`.