### PR TITLE
feat: support booleans, integers in android

### DIFF
--- a/android/src/main/java/com/robinpowered/RNMDMManager/RNMobileDeviceManagerModule.java
+++ b/android/src/main/java/com/robinpowered/RNMDMManager/RNMobileDeviceManagerModule.java
@@ -160,7 +160,17 @@ public class RNMobileDeviceManagerModule extends ReactContextBaseJavaModule impl
             Bundle appRestrictions = restrictionsManager.getApplicationRestrictions();
             WritableNativeMap data = new WritableNativeMap();
             for (String key : appRestrictions.keySet()){
-                data.putString(key, appRestrictions.getString(key));
+                Object value = appRestrictions.get(key);
+                
+                if (value instanceof  Boolean) {
+                    data.putBoolean(key, (Boolean) value);
+                } else if (value instanceof  Integer) {
+                    data.putInt(key, (Integer) value);
+                } else if (value instanceof String)  {
+                    data.putString(key, (String) value);
+                } else {
+                    data.putString(key, value.toString());
+                }
             }
             promise.resolve(data);
         } else {


### PR DESCRIPTION
Currently, for configurations in Android which are booleans or integers, the values are not bridged accurately to React-Native.

In the case of booleans, they always converted to null.
In the case of integers, they are converted to strings.

This pr determines whether type of the restriction value (integer, boolean, or string) and then writes the correct type to the WritableMap which is bridged to React-Native.

To test:
1. Set boolean and integer values in your managed configurations.
2. Confirm that they are booleans and integers